### PR TITLE
Update README with stripe link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stripe for Elixir
 
-An Elixir library for working with Stripe. With this library you can:
+An Elixir library for working with [Stripe](https://stripe.com/). With this library you can:
 
  - manage Customers
  - Create, list, cancel, update and delete Subscriptions


### PR DESCRIPTION
This adds a link to Stripe to the README. This seems like a good idea for (a) people who stumple across this and do not know Stripe and (b) people like me who are too lazy to type.

*Edit* And yes, I am a bit embarrased about this PR (in the same way one is after eating a whole bucket of chicken at KFC). :neckbeard: 