### PR TITLE
Add accounts requests on Stripe connect 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ An Elixir library for working with [Stripe](https://stripe.com/). With this libr
  - Create, list, and update Invoices
  - Create and retrieve tokens for credit card and bank account
  - List and retrieve stripe events (paged, max 100 per page, up to 30 days kept on stripe for retrieve)
+ - manage Accounts [Stripe connected account](https://stripe.com/connect)
  - And yes, run charges with or without an existing Customer
 
 Why another Stripe Library? Currently there are a number of them in the Elixir world that are, well just not "done" yet. I started to fork/help but soon it became clear to me that what I wanted was:

--- a/lib/stripe/accounts.ex
+++ b/lib/stripe/accounts.ex
@@ -1,0 +1,157 @@
+defmodule Stripe.Accounts do
+  @moduledoc """
+  Main API for working with Customers at Stripe. Through this API you can:
+  -create accounts
+  -get single account
+  -delete single account
+  -delete all account
+  -count account
+
+  https://stripe.com/docs/api/curl#account_object
+  """
+
+  @endpoint "accounts"
+
+  @doc """
+  Creates an Account with the given parameters
+
+  At the bare minimum, to create and connect to a managed account, simply set
+  managed to true in the creation request, and provide a country. The country,
+  once set, cannot be changed.
+
+  https://stripe.com/docs/connect/managed-accounts
+
+  ## Example
+
+  ```
+    new_account = [
+      email: "test@example.com",
+      managed: true,
+      tos_acceptance: [
+        date: :os.system_time(:seconds),
+        ip: "127.0.0.1"
+      ],
+      legal_entity: [
+        type: "individual",
+        dob: [
+          day: 1,
+          month: 1,
+          year: 1991
+        ],
+        first_name: "John",
+        last_name: "Doe"
+      ],
+      external_account: [
+        object: "bank_account",
+        country: "US",
+        currency: "usd",
+        routing_number: "110000000",
+        account_number: "000123456789"
+      ]
+    ]
+    {:ok, res} = Stripe.Accounts.create new_account
+  ```
+
+  """
+  def create(params) do
+    Stripe.make_request(:post, @endpoint, params)
+      |> Stripe.Util.handle_stripe_response
+  end
+
+  @doc """
+  Retrieves a given Account with the specified ID. Returns 404 if not found.
+  ## Example
+
+  ```
+    Stripe.Accounts.get "account_id"
+  ```
+
+  """
+  def get(id) do
+    Stripe.make_request(:get, "#{@endpoint}/#{id}")
+      |> Stripe.Util.handle_stripe_response
+  end
+
+  @max_fetch_size 100
+  @doc """
+  List all accounts.
+
+  ##Example
+
+  ```
+  {:ok, accounts} = Stripe.Accounts.all
+  ```
+
+  """
+  def all( accum \\ [], startingAfter \\ "") do
+    case Stripe.Util.list_raw("#{@endpoint}",@max_fetch_size, startingAfter) do
+      {:ok, resp}  ->
+        case resp[:has_more] do
+          true ->
+            last_sub = List.last( resp[:data] )
+            all( resp[:data] ++ accum, last_sub["id"] )
+          false ->
+            result = resp[:data] ++ accum
+            {:ok, result}
+        end
+    {:error, err} -> raise err
+    end
+  end
+
+  @doc """
+  Deletes a Account with the specified ID
+
+  ## Example
+
+  ```
+    Stripe.Accounts.delete "account_id"
+  ```
+  """
+  def delete(id) do
+    Stripe.make_request(:delete, "#{@endpoint}/#{id}")
+      |> Stripe.Util.handle_stripe_response
+  end
+
+  @doc """
+  Deletes all Accounts
+
+  ## Example
+
+  ```
+  Stripe.Accounts.delete_all
+  ```
+  """
+  def delete_all do
+    case all  do
+      {:ok, accounts} ->
+        Enum.each accounts, fn c -> delete(c["id"]) end
+      {:error, err} -> raise err
+    end
+  end
+
+  @doc """
+  Count total number of accounts.
+
+  ## Example
+  ```
+  {:ok, count} = Stripe.Accounts.count
+  ```
+  """
+  def count do
+    Stripe.Util.count "#{@endpoint}"
+  end
+
+  @doc """
+  Returns a list of Accounts with a default limit of 10 which you can override with `list/1`
+
+  ## Example
+
+  ```
+    {:ok, accounts} = Stripe.Accounts.list(20)
+  ```
+  """
+  def list(limit \\ 10) do
+    Stripe.make_request(:get, "#{@endpoint}?limit=#{limit}")
+      |> Stripe.Util.handle_stripe_response
+  end
+end

--- a/test/stripe/account_test.exs
+++ b/test/stripe/account_test.exs
@@ -1,0 +1,86 @@
+defmodule Stripe.AccountTest do
+  use ExUnit.Case
+
+  setup_all do
+    Stripe.Accounts.delete_all
+
+    new_account = [
+      email: "test@example.com",
+      managed: true,
+      tos_acceptance: [
+        date: :os.system_time(:seconds),
+        ip: "127.0.0.1"
+      ],
+      legal_entity: [
+        type: "individual",
+        address: [
+          city: "Los Angeles",
+          country: "US",
+          line1: "1st Ave",
+          postal_code: "910000",
+          state: "CA"
+        ],
+        dob: [
+          day: 1,
+          month: 1,
+          year: 1991
+        ],
+        first_name: "John",
+        last_name: "Doe"
+      ],
+      external_account: [
+        object: "bank_account",
+        country: "US",
+        currency: "usd",
+        routing_number: "110000000",
+        account_number: "000123456789"
+      ]
+    ]
+    case Stripe.Accounts.create new_account do
+      {:ok, account} ->
+        on_exit fn ->
+          Stripe.Accounts.delete account.id
+        end
+        {:ok, [account: account]}
+
+      {:error, err} -> flunk err
+    end
+  end
+
+  @tag disabled: false
+  test "Create works", %{account: account} do
+    assert account.id
+  end
+
+  @tag disabled: false
+  test "Retrieve list works" do
+    {:ok, accounts} = Stripe.Accounts.list
+    assert length(accounts) > 0
+  end
+
+  @tag disabled: false
+  test "Retrieve single works", %{account: account} do
+    case Stripe.Accounts.get account.id do
+      {:ok, found} -> assert found.id == account.id
+      {:error, err} -> flunk err
+    end
+  end
+
+  test "Delete single works", %{account: account} do
+    case Stripe.Accounts.delete account.id do
+      {:ok, res} -> assert res.deleted
+      {:error, err} -> flunk err
+    end
+  end
+
+  test "Delete all works", %{account: _} do
+   Helper.create_test_account "test1@example.com"
+   Helper.create_test_account "test2@example.com"
+   Stripe.Accounts.delete_all
+
+    case Stripe.Accounts.count do
+      {:ok, cnt} -> assert cnt == 0
+      {:error, err} -> flunk err
+    end
+  end
+end

--- a/test/stripe/tokens_test.exs
+++ b/test/stripe/tokens_test.exs
@@ -77,7 +77,7 @@ defmodule Stripe.TokensTest do
       {:ok, res} ->
         #Apex.ap res
         assert res.id
-        assert res.status == "paid"
+        assert res.status == "succeeded"
         assert res.paid == true
         assert res.object == "charge"
         {:error, err} -> flunk err

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -28,4 +28,17 @@ defmodule Helper do
     {:ok, res} = Stripe.Customers.create new_customer
     res
   end
+
+  def create_test_account(email) do
+    new_account = [
+      email: email,
+      managed: true,
+      legal_entity: [
+        type: "individual"
+      ]
+    ]
+    {:ok, res} = Stripe.Accounts.create new_account
+    res
+  end
 end
+


### PR DESCRIPTION
Hi, I added accounts API client for managing accounts on Stripe connect. Mainly for the *managed* accounts in my case. I thought someone else may find it useful, hence the PR :).  

Resources:

https://stripe.com/docs/connect/managed-accounts
https://stripe.com/docs/api/curl#account