### PR TITLE
allow `poison ~> 1.5`

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule Stripe.Mixfile do
   defp deps(:prod) do
     [
       {:httpoison, "~> 0.8.2" },
-      {:poison, "~> 2.1.0", optional: true},
+      {:poison, "~> 1.5 or ~> 2.1.0", optional: true},
       {:ex_doc, "~> 0.7", only: :dev},
       {:earmark, ">= 0.0.0", only: :dev}
     ]


### PR DESCRIPTION
Lots of packages still depend on older `poison` versions and hex fail to resolve.
To make resolution to work I had to add `~> 1.5`