### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stripe for Elixir [![Build Status](https://travis-ci.org/robconery/stripity-stripe.svg?branch=master)](https://travis-ci.org/robconery/stripity-stripe) [![Hex.pm](https://img.shields.io/hexpm/v/stripity_stripe.svg?maxAge=2592000)](https://hex.pm/packages/stripity_stripe) [![Hex.pm](https://img.shields.io/hexpm/dt/stripity_stripe.svg?maxAge=2592000)](https://hex.pm/packages/stripity_stripe) [![Inline docs](http://inch-ci.org/github/robconery/stripity-stripe.svg)](http://inch-ci.org/github/robconery/stripity-stripe) [![Coverage Status](https://coveralls.io/repos/github/robconery/stripity-stripe/badge.svg?branch=master)](https://coveralls.io/github/robconery/stripity-stripe?branch=master)
 
-An Elixir library for working [Stripe](https://stripe.com/).
+An Elixir library for working with [Stripe](https://stripe.com/).
 
  - Manage accounts (your own, standalone/managed via connect) [Stripe.Accounts](https://github.com/robconery/stripity-stripe/blob/master/lib/stripe/accounts.ex)
  - Manage customers [Stripe.Customers](https://github.com/robconery/stripity-stripe/blob/master/lib/stripe/customers.ex)


### PR DESCRIPTION
This line should be "An Elixir library for working [with] Stripe."