### PR TITLE
add uri tests

### DIFF
--- a/lib/stripe/uri.ex
+++ b/lib/stripe/uri.ex
@@ -37,8 +37,8 @@ defmodule Stripe.URI do
       Enumerable.impl_for(value) ->
         pair(to_string(key), [], value)
       true ->
-        param_name = key |> to_string |> URI.encode
-        param_value = value |> to_string |> URI.encode
+        param_name = key |> to_string |> URI.encode_www_form
+        param_value = value |> to_string |> URI.encode_www_form
 
         "#{param_name}=#{param_value}"
     end
@@ -57,7 +57,7 @@ defmodule Stripe.URI do
 
   defp build_key(root, parents) do
     path = Enum.map_join parents, "", fn x ->
-      param = x |> to_string |> URI.encode
+      param = x |> to_string |> URI.encode_www_form
       "[#{param}]"
     end
 

--- a/test/stripe/uri_test.exs
+++ b/test/stripe/uri_test.exs
@@ -1,0 +1,38 @@
+defmodule Stripe.UriTest do
+  use ExUnit.Case
+
+  test "keyword list encoding" do
+    assert Stripe.URI.encode_query([a: 1]) == "a=1"
+    assert Stripe.URI.encode_query([a: 1, b: 2]) == "a=1&b=2"
+    assert Stripe.URI.encode_query(["a": "1", "b": "2"]) == "a=1&b=2"
+    assert Stripe.URI.encode_query([a: nil, b: nil]) == "a=&b="
+    assert Stripe.URI.encode_query(["foo z": "true"]) == "foo+z=true"
+    assert Stripe.URI.encode_query(["test &": "test &"]) == "test+%26=test+%26"
+    assert Stripe.URI.encode_query([a: "4test ~1.x"]) == "a=4test+~1.x"
+    assert Stripe.URI.encode_query([a: "poll:146%"]) == "a=poll%3A146%25"
+    assert Stripe.URI.encode_query([a: "/\n+/ゆ"]) == "a=%2F%0A%2B%2F%E3%82%86"
+    assert Stripe.URI.encode_query([a: "/\n+/ゆ"]) == "a=%2F%0A%2B%2F%E3%82%86"
+  end
+
+  test "nested list encoding" do
+    assert Stripe.URI.encode_query([a: [a: 1]]) == "a[a]=1"
+    assert Stripe.URI.encode_query([a: [b: 1]]) == "a[b]=1"
+    assert Stripe.URI.encode_query([a: [b: [c: 1]]]) == "a[b][c]=1"
+    assert Stripe.URI.encode_query([a: [b: ["test &": "test &"]]]) == "a[b][test+%26]=test+%26"
+    assert Stripe.URI.encode_query([a: [a: "/\n+/ゆ"]]) == "a[a]=%2F%0A%2B%2F%E3%82%86"
+    assert Stripe.URI.encode_query(%{a: [a: "test &"]}) == "a[a]=test+%26"
+  end
+
+  test "map list encoding" do
+    assert Stripe.URI.encode_query(%{a: 1}) == "a=1"
+    assert Stripe.URI.encode_query(%{a: 1, b: 2}) == "a=1&b=2"
+    assert Stripe.URI.encode_query(%{"a": "1", "b": "2"}) == "a=1&b=2"
+    assert Stripe.URI.encode_query(%{a: nil, b: nil}) == "a=&b="
+    assert Stripe.URI.encode_query(%{"foo z": "true"}) == "foo+z=true"
+    assert Stripe.URI.encode_query(%{"test &": "test &"}) == "test+%26=test+%26"
+    assert Stripe.URI.encode_query(%{a: "4test ~1.x"}) == "a=4test+~1.x"
+    assert Stripe.URI.encode_query(%{a: "poll:146%"}) == "a=poll%3A146%25"
+    assert Stripe.URI.encode_query(%{a: "/\n+/ゆ"}) == "a=%2F%0A%2B%2F%E3%82%86"
+    assert Stripe.URI.encode_query(%{a: "/\n+/ゆ"}) == "a=%2F%0A%2B%2F%E3%82%86"
+  end
+end


### PR DESCRIPTION
After starting to add some tests, I realized that the current URI implementation is very broken.  Some of these tests are still failing.

I strongly suggest deprecating the usage of keyword lists as arguments, and only use maps.  

***Don't do this***:
```elixir
  card = [
    card: [
      number: 424242424242,
      exp_year: 2014
    ]
  ]
```

***But, do this:***
```elixir
  card = %{
    card: %{
      number: 424242424242,
      exp_year: 2014
    }
  }
```

Then you can delegate all of the query string formatting directly to Elixir's `URI.encode_query` implementation, which will handle it properly.