### PR TITLE
Allow passing custom options to HTTPoison

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,21 @@ defp application do
 end
 ```
 
-Then create a config folder and add a Stripe secret key (and optional platform client id if you are using Stripe Connect):
+## Configuration
+
+To make API calls, it is necessary to configure your Stripe secret key (and optional platform client id if you are using Stripe Connect):
 
 ```ex
 use Mix.Config
 
 config :stripity_stripe, secret_key: "YOUR SECRET KEY"
 config :stripity_stripe, platform_client_id: "YOUR CONNECT PLATFORM CLIENT ID"
+```
+
+To customize the underlying HTTPoison library, you may optionally add an `:httpoison_options` key to the stripity_stripe configuration.  For a full list of configuration options, please refer to the [HTTPoison documentation](https://github.com/edgurgel/httpoison).
+
+```ex
+config :stripity_stripe, httpoison_options: [timeout: 10000, recv_timeout: 10000, proxy: {"proxy.mydomain.com", 8080}]
 ```
 
 ## Testing
@@ -99,6 +107,7 @@ case events[:has_more] do
     false -> events[:data]
 end
 ```
+
 <a name="connect"></a>
 # Connect
 

--- a/lib/stripe.ex
+++ b/lib/stripe.ex
@@ -91,6 +91,7 @@ defmodule Stripe do
         |> Map.merge(headers)
         |> Map.to_list
 
+    options = Keyword.merge(httpoison_request_options(), options)
     {:ok, response} = request(method, endpoint, rb, rh, options)
     response.body
   end
@@ -114,9 +115,10 @@ defmodule Stripe do
   """
   def make_oauth_token_callback_request(body) do
     rb = Stripe.URI.encode_query(body)
-    rh = req_headers( Stripe.config_or_env_key )
-        |> Map.to_list
-        options = []
+    rh = req_headers(Stripe.config_or_env_key)
+      |> Map.to_list
+
+    options = httpoison_request_options()
     HTTPoison.request(:post, "#{Stripe.Connect.base_url}oauth/token", rb, rh, options)
   end
 
@@ -127,9 +129,9 @@ defmodule Stripe do
       stripe_user_id: stripe_user_id,
       client_id: Stripe.config_or_env_platform_client_id])
     rh = req_headers( Stripe.config_or_env_key)
-    |> Map.to_list
+      |> Map.to_list
 
-    options = []
+    options = httpoison_request_options()
     HTTPoison.request(:post, "#{Stripe.Connect.base_url}oauth/deauthorize", rb, rh, options)
   end
 
@@ -141,4 +143,7 @@ defmodule Stripe do
     end
   end
 
+  defp httpoison_request_options() do
+    Application.get_env(:stripity_stripe, :httpoison_options, [])
+  end
 end


### PR DESCRIPTION
Allows passing custom options to HTTPoison.

I've received a small handful of `timeout` errors over the past couple weeks, so I'd like to bump up the `recv_timeout` to a value greater than the default (of 5 seconds).