### PR TITLE
Fix test for Stripe.URI

### DIFF
--- a/lib/stripe/uri.ex
+++ b/lib/stripe/uri.ex
@@ -50,7 +50,7 @@ defmodule Stripe.URI do
         Enumerable.impl_for(value) ->
           pair(root, parents ++ [key], value)
         true ->
-          build_key(root, parents ++ [key]) <> to_string(value)
+          build_key(root, parents ++ [key]) <> URI.encode_www_form(to_string(value))
       end
     end
   end


### PR DESCRIPTION
Partially addresses https://github.com/robconery/stripity-stripe/issues/51, e.g. fixes the test.