### PR TITLE
Remove warnings in tests

### DIFF
--- a/test/stripe/card_test.exs
+++ b/test/stripe/card_test.exs
@@ -84,7 +84,7 @@ defmodule Stripe.CardTest do
     use_cassette "card_test/list", match_requests_on: [:query, :request_body] do
       case Stripe.Cards.list :customer, customer.id, "", 1 do
         {:ok, res} ->
-          assert Dict.size(res[:data]) == 1
+          assert length(res[:data]) == 1
           {:error, err} -> flunk err
       end
     end
@@ -95,7 +95,7 @@ defmodule Stripe.CardTest do
     use_cassette "card_test/list_with_key", match_requests_on: [:query, :request_body] do
       case Stripe.Cards.list :customer, customer.id, Stripe.config_or_env_key,"", 1 do
         {:ok, res} ->
-          assert Dict.size(res[:data]) == 1
+          assert length(res[:data]) == 1
           {:error, err} -> flunk err
       end
     end
@@ -106,7 +106,7 @@ defmodule Stripe.CardTest do
     use_cassette "card_test/all", match_requests_on: [:query, :request_body] do
       case Stripe.Cards.all :customer, customer.id, [],"" do
         {:ok, cards} ->
-          assert Dict.size(cards) > 0
+          assert length(cards) > 0
           {:error, err} -> flunk err
       end
     end
@@ -117,7 +117,7 @@ defmodule Stripe.CardTest do
     use_cassette "card_test/all_with_key", match_requests_on: [:query, :request_body] do
       case Stripe.Cards.all :customer, customer.id, Stripe.config_or_env_key, [], "" do
         {:ok, cards} ->
-          assert Dict.size(cards) > 0
+          assert length(cards) > 0
           {:error, err} -> flunk err
       end
     end

--- a/test/stripe/customer_test.exs
+++ b/test/stripe/customer_test.exs
@@ -89,7 +89,7 @@ defmodule Stripe.CustomerTest do
     use_cassette "customer_test/list", match_requests_on: [:query, :request_body] do
       case Stripe.Customers.list "", 1 do
         {:ok, res} ->
-          assert Dict.size(res[:data]) == 1
+          assert length(res[:data]) == 1
           {:error, err} -> flunk err
       end
     end
@@ -100,7 +100,7 @@ defmodule Stripe.CustomerTest do
     use_cassette "customer_test/list_with_key", match_requests_on: [:query, :request_body] do
       case Stripe.Customers.list Stripe.config_or_env_key,"", 1 do
         {:ok, res} ->
-          assert Dict.size(res[:data]) == 1
+          assert length(res[:data]) == 1
           {:error, err} -> flunk err
       end
     end
@@ -111,7 +111,7 @@ defmodule Stripe.CustomerTest do
     use_cassette "customer_test/all", match_requests_on: [:query, :request_body] do
       case Stripe.Customers.all [],"" do
         {:ok, custs} ->
-          assert Dict.size(custs) > 0
+          assert length(custs) > 0
           {:error, err} -> flunk err
       end
     end
@@ -122,7 +122,7 @@ defmodule Stripe.CustomerTest do
     use_cassette "customer_test/all_with_key", match_requests_on: [:query, :request_body] do
       case Stripe.Customers.all Stripe.config_or_env_key, [], "" do
         {:ok, custs} ->
-          assert Dict.size(custs) > 0
+          assert length(custs) > 0
           {:error, err} -> flunk err
       end
     end

--- a/test/stripe/events_test.exs
+++ b/test/stripe/events_test.exs
@@ -49,7 +49,7 @@ defmodule Stripe.EventsTest do
     use_cassette "events_test/list", match_requests_on: [:query, :request_body] do
       case Stripe.Events.list "",5 do
         {:ok, events} ->
-          assert Dict.size(events[:data]) > 0
+          assert length(events[:data]) > 0
           {:error, err} -> flunk err
       end
     end
@@ -59,7 +59,7 @@ defmodule Stripe.EventsTest do
   test "List w/key works" do
     use_cassette "events_test/list_with_key", match_requests_on: [:query, :request_body] do
       case Stripe.Events.list Stripe.config_or_env_key,"", 5 do
-        {:ok, events} -> assert Dict.size(events[:data]) > 0
+        {:ok, events} -> assert length(events[:data]) > 0
         {:error, err} -> flunk err
       end
     end
@@ -74,7 +74,7 @@ defmodule Stripe.EventsTest do
         true ->
           last = List.last( events[:data] )
           case Stripe.Events.list Stripe.config_or_env_key,last["id"], 1 do
-            {:ok, events} -> assert Dict.size(events[:data]) > 0
+            {:ok, events} -> assert length(events[:data]) > 0
             {:error,err} -> flunk err
           end
           false -> flunk "should have had more than 1 page. Check setup to make sure theres enough events for the test to run properly (5+)"

--- a/test/stripe/invoices_test.exs
+++ b/test/stripe/invoices_test.exs
@@ -73,7 +73,7 @@ defmodule Stripe.InvoicesTest do
     use_cassette "invoices_test/list", match_requests_on: [:query, :request_body] do
       case Stripe.Invoices.list "",1 do
         {:ok, res} ->
-          assert Dict.size(res[:data]) == 1
+          assert length(res[:data]) == 1
           {:error, err} -> flunk err
       end
     end
@@ -83,7 +83,7 @@ defmodule Stripe.InvoicesTest do
   test "List w/key works", %{}  do
     use_cassette "invoices_test/list_with_key", match_requests_on: [:query, :request_body] do
       case Stripe.Invoices.list Stripe.config_or_env_key, "", 1 do
-        {:ok, lst} -> assert Dict.size(lst[:data]) == 1
+        {:ok, lst} -> assert length(lst[:data]) == 1
         {:error, err} -> flunk err
       end
     end
@@ -97,7 +97,7 @@ defmodule Stripe.InvoicesTest do
         true ->
           last = List.last( invoices[:data] )
           case Stripe.Invoices.list Stripe.config_or_env_key,last["id"], 1 do
-            {:ok, invoices} -> assert Dict.size(invoices[:data]) > 0
+            {:ok, invoices} -> assert length(invoices[:data]) > 0
             {:error,err} -> flunk err
           end
           _ -> flunk "should have had more than 1 page. Check setup to make sure theres enough invoices for the test to run properly (5+)"

--- a/test/stripe/util_test.exs
+++ b/test/stripe/util_test.exs
@@ -54,7 +54,7 @@ defmodule Stripe.UtilTest do
     use_cassette "util_test/list", match_requests_on: [:query, :request_body] do
       case Stripe.Util.list "plans" do
         {:ok, resp} ->
-          assert Dict.size(resp[:data]) == 2
+          assert length(resp[:data]) == 2
           {:error, err} -> flunk err
       end
     end
@@ -64,7 +64,7 @@ defmodule Stripe.UtilTest do
   test "list w/key works" do
     use_cassette "util_test/list_with_key", match_requests_on: [:query, :request_body] do
       case Stripe.Util.list "plans", Stripe.config_or_env_key,  "", 2  do
-        {:ok, resp} -> assert Dict.size( resp[:data]) == 2
+        {:ok, resp} -> assert length( resp[:data]) == 2
         {:error, err} -> flunk err
       end
     end


### PR DESCRIPTION
This remove the following warning from tests:

```
Keyword.size/1 is deprecated, please use Kernel.length/1
```