### PR TITLE
Allow changing subscription options

### DIFF
--- a/fixture/vcr_cassettes/subscription_test/general_change.json
+++ b/fixture/vcr_cassettes/subscription_test/general_change.json
@@ -1,0 +1,36 @@
+[
+  {
+    "request": {
+      "body": "quantity=3",
+      "headers": {
+        "Authorization": "Bearer non_empty_secret_key_string",
+        "Content-Type": "application/x-www-form-urlencoded",
+        "User-Agent": "Stripe/v1 stripity-stripe/1.4.0"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.stripe.com/v1/customers/cus_8r2iLZ3me9G4hU/subscriptions/sub_8r2ikymYYXhIlq"
+    },
+    "response": {
+      "body": "{\n  \"id\": \"sub_8y7w4NdKIXnqxX\",\n  \"object\": \"subscription\",\n  \"application_fee_percent\": null,\n  \"cancel_at_period_end\": false,\n  \"canceled_at\": null,\n  \"created\": 1470654766,\n  \"current_period_end\": 1473333166,\n  \"current_period_start\": 1470654766,\n  \"customer\": \"cus_8y7wNj0nBcLB5e\",\n  \"discount\": null,\n  \"ended_at\": null,\n  \"livemode\": false,\n  \"metadata\": {},\n  \"plan\": {\n    \"id\": \"test-std\",\n    \"object\": \"plan\",\n    \"amount\": 100,\n    \"created\": 1470654762,\n    \"currency\": \"usd\",\n    \"interval\": \"month\",\n    \"interval_count\": 1,\n    \"livemode\": false,\n    \"metadata\": {},\n    \"name\": \"Test Plan Standard\",\n    \"statement_descriptor\": null,\n    \"trial_period_days\": null\n  },\n  \"quantity\": 3,\n  \"start\": 1470654768,\n  \"status\": \"active\",\n  \"tax_percent\": null,\n  \"trial_end\": null,\n  \"trial_start\": null\n}\n",
+      "headers": {
+        "Server": "nginx",
+        "Date": "Mon, 08 Aug 2016 11:12:49 GMT",
+        "Content-Type": "application/json",
+        "Content-Length": "816",
+        "Connection": "keep-alive",
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Methods": "GET, POST, HEAD, OPTIONS, DELETE",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Max-Age": "300",
+        "Cache-Control": "no-cache, no-store",
+        "Request-Id": "req_8y7wpied7ZXcN7",
+        "Stripe-Version": "2016-07-06",
+        "Strict-Transport-Security": "max-age=31556926; includeSubDomains"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/lib/stripe/subscriptions.ex
+++ b/lib/stripe/subscriptions.ex
@@ -109,7 +109,7 @@ defmodule Stripe.Subscriptions do
   Stripe.Customers.change_subscription "customer_id", "subscription_id", "plan_id", key
   ```
   """
-  def change(customer_id, sub_id, plan_id, key) do
+  def change(customer_id, sub_id, plan_id, key) when is_binary(plan_id) do
     Stripe.make_request_with_key(:post, "#{@endpoint}/#{customer_id}/subscriptions/#{sub_id}", key, [plan: plan_id])
     |> Stripe.Util.handle_stripe_response
   end

--- a/test/stripe/subscription_test.exs
+++ b/test/stripe/subscription_test.exs
@@ -131,6 +131,16 @@ defmodule Stripe.SubscriptionTest do
   end
 
   @tag disabled: false
+  test "General change works", %{ customer: customer, sub1: sub1 } do
+    use_cassette "subscription_test/general_change", match_requests_on: [:query, :request_body] do
+      case Stripe.Subscriptions.change customer.id, sub1.id, [quantity: 3] do
+        {:ok, changed} -> assert changed[:quantity] == 3
+        {:error, err} -> flunk err
+      end
+    end
+  end
+
+  @tag disabled: false
   test "Change w/key works", %{customer: customer, sub1: _, sub2: sub2} do
     use_cassette "subscription_test/change_with_key", match_requests_on: [:query, :request_body] do
       case Stripe.Subscriptions.change customer.id, sub2.id, "test-dlz", Stripe.config_or_env_key do


### PR DESCRIPTION
Changing subscriptions was always possible. However previously, [`change(customer_id, sub_id, opts, key)`](https://github.com/robconery/stripity-stripe/pull/70/files#diff-fee1e392bcadd3ea46365930054f7f3dR126) was shadowed by its [similar-looking clause](https://github.com/robconery/stripity-stripe/pull/70/files#diff-fee1e392bcadd3ea46365930054f7f3dR112).

Closes #35