### PR TITLE
Add Coupons module

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Features:
 * manage tokens for credit card and bank account [Stripe.Tokens](https://github.com/robconery/stripity-stripe/blob/master/lib/stripe/tokens.ex)
 * list and retrieve stripe events (paged, max 100 per page, up to 30 days kept on stripe for retrieve) [Stripe.Events](https://github.com/robconery/stripity-stripe/blob/master/lib/stripe/events.ex)
 * manage/capture charges with or without an existing Customer [Stripe.Charges](https://github.com/robconery/stripity-stripe/blob/master/lib/stripe/charges.ex)
+* manage and validate coupons [Stripe.Coupons](https://github.com/robconery/stripity-stripe/blob/master/lib/stripe/coupons.ex)
 * facilitate using the Connect API (for standalone/managed accounts) [Stripe Connect](https://stripe.com/docs/connect) by allowing you to supply your own key. The oauth callback processor (not endpoint) is supplied by this library as well as a connect button url generator. See below for [Instructions](#connect). [Stripe Connect API reference](https://stripe.com/docs/connect/reference)
 * all functions are available with a parameter that allow a stripe api key to be passed in and be used for the underlying request. This api key would be the one obtained by the oauth connect authorize workflow.
 

--- a/fixture/vcr_cassettes/coupons_test/retrieve.json
+++ b/fixture/vcr_cassettes/coupons_test/retrieve.json
@@ -1,0 +1,36 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "Authorization": "Bearer non_empty_secret_key_string",
+        "Content-Type": "application/x-www-form-urlencoded",
+        "User-Agent": "Stripe/v1 stripity-stripe/1.4.0"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.stripe.com/v1/coupons/free-1-month"
+    },
+    "response": {
+      "body": "{\n  \"id\": \"free-1-month\",\n  \"object\": \"coupon\",\n  \"amount_off\": null,\n  \"created\": 1452612120,\n  \"currency\": null,\n  \"duration\": \"repeating\",\n  \"duration_in_months\": 1,\n  \"livemode\": false,\n  \"max_redemptions\": null,\n  \"metadata\": {},\n  \"percent_off\": 100,\n  \"redeem_by\": null,\n  \"times_redeemed\": 0,\n  \"valid\": true\n}\n",
+      "headers": {
+        "Server": "nginx",
+        "Date": "Mon, 15 Aug 2016 01:59:24 GMT",
+        "Content-Type": "application/json",
+        "Content-Length": "319",
+        "Connection": "keep-alive",
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Methods": "GET, POST, HEAD, OPTIONS, DELETE",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Max-Age": "300",
+        "Cache-Control": "no-cache, no-store",
+        "Request-Id": "req_90bbU6ZDHzfxBg",
+        "Stripe-Version": "2016-03-07",
+        "Strict-Transport-Security": "max-age=31556926; includeSubDomains"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/lib/stripe.ex
+++ b/lib/stripe.ex
@@ -107,7 +107,7 @@ defmodule Stripe do
   * options - request options
   Returns tuple
   """
-  def make_request(method, endpoint, body \\ [], headers \\ [], options \\ []) do
+  def make_request(method, endpoint, body \\ %{}, headers \\ %{}, options \\ []) do
     make_request_with_key( method, endpoint, config_or_env_key(), body, headers, options )
   end
 

--- a/lib/stripe/coupons.ex
+++ b/lib/stripe/coupons.ex
@@ -1,0 +1,34 @@
+defmodule Stripe.Coupons do
+  @moduledoc """
+  Handles coupons to the Stripe API.
+  (API ref: https://stripe.com/docs/api#coupons)
+
+  Operations:
+  - create (TODO)
+  - retrieve
+  - update (TODO)
+  - delete (TODO)
+  - list (TODO)
+  """
+
+  @endpoint "coupons"
+
+  @doc """
+  Retrieves the coupon with the given ID.
+  Returns a coupon if a valid coupon ID was provided.
+  Throws an error otherwise.
+
+  ## Examples
+  ```
+    params = "free-1-month"
+
+    {:ok, result} = Stripe.Coupons.retrieve params
+  ```
+  """
+  def retrieve(params) do
+    path = @endpoint <> "/" <> params
+
+    Stripe.make_request(:get, path, %{}, %{})
+    |> Stripe.Util.handle_stripe_response
+  end
+end

--- a/test/stripe/coupons_test.exs
+++ b/test/stripe/coupons_test.exs
@@ -1,0 +1,17 @@
+defmodule Stripe.CouponsTest do
+  use ExUnit.Case
+  use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
+
+  @tags disabled: false
+  test "Validate coupon with coupon id" do
+    use_cassette "coupons_test/retrieve", match_requests_on: [:query, :request_body] do
+      params = "free-1-month"
+
+      case Stripe.Coupons.retrieve(params) do
+        {:ok, res} ->
+          assert res.id == params
+        {:error, err} -> flunk err
+      end
+    end
+  end
+end


### PR DESCRIPTION
I added a `Coupons` module. Currently I only need the `retrieve/1` method for a coupon validation endpoint so that's all I added, but the rest can be added later. 

- fix type disparity between make_request and make_request_with_key
- add coupons functionality
- add `retrieve/1`
- add test for `retrieve/1`