### PR TITLE
Removing env parameter from deps to allow for arbitrary mix environments

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule Stripe.Mixfile do
         "vcr.check": :test,
         "vcr.show": :test
       ],
-      deps: deps(Mix.env) ]
+      deps: deps]
   end
 
   # Configuration for the OTP application
@@ -28,15 +28,7 @@ defmodule Stripe.Mixfile do
     ]
   end
 
-  defp deps(:dev) do
-    deps(:prod)
-  end
-
-  defp deps(:test) do
-    deps(:dev)
-  end
-
-  defp deps(:prod) do
+  defp deps do
     [
       {:httpoison, ">= 0.0.0" },
       {:poison, ">= 0.0.0", optional: true},


### PR DESCRIPTION
Essentially identical to Issue #53 which was closed because of hashes which now exist in mainline. 

Without this change EXRM is not very usable, and the parameter to dep's largely does nothing. So removing it. 